### PR TITLE
Add filtering, sorting and pagination to expenses

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,23 @@
+# Expense Tracker Backend
+
+## `/expenses` GET Query Parameters
+
+The `GET /expenses` endpoint now supports filtering, sorting and pagination.
+
+| Parameter      | Description                                                     |
+|---------------|-----------------------------------------------------------------|
+| `sort`        | One of `date_desc` (default), `date_asc`, `amount_desc`, `amount_asc` |
+| `type`        | Filter by `ExpenseType`                                          |
+| `date`        | Exact date (ISO-8601)                                            |
+| `dateFrom`    | Start of date range (ISO-8601)                                   |
+| `dateTo`      | End of date range (ISO-8601)                                     |
+| `amount`      | Exact amount                                                     |
+| `amountFrom`  | Minimum amount                                                   |
+| `amountTo`    | Maximum amount                                                   |
+| `isRecurring` | Filter recurring expenses                                        |
+| `search`      | Case-insensitive search in name or description                   |
+| `page`        | Page number (0 based)                                            |
+| `size`        | Page size                                                        |
+
+If `page` and `size` are provided the result is paginated; otherwise all
+matching expenses are returned.

--- a/src/main/kotlin/com/nv/expensetracker/database/repository/ExpenseFilter.kt
+++ b/src/main/kotlin/com/nv/expensetracker/database/repository/ExpenseFilter.kt
@@ -1,0 +1,19 @@
+package com.nv.expensetracker.database.repository
+
+import com.nv.expensetracker.controllers.enums.ExpenseType
+import java.time.Instant
+
+/**
+ * Filter parameters for searching expenses.
+ */
+data class ExpenseFilter(
+    val type: ExpenseType? = null,
+    val date: Instant? = null,
+    val dateFrom: Instant? = null,
+    val dateTo: Instant? = null,
+    val amount: Int? = null,
+    val amountFrom: Int? = null,
+    val amountTo: Int? = null,
+    val isRecurring: Boolean? = null,
+    val search: String? = null,
+)

--- a/src/main/kotlin/com/nv/expensetracker/database/repository/ExpenseRepository.kt
+++ b/src/main/kotlin/com/nv/expensetracker/database/repository/ExpenseRepository.kt
@@ -4,7 +4,7 @@ import com.nv.expensetracker.database.model.Expense
 import org.bson.types.ObjectId
 import org.springframework.data.mongodb.repository.MongoRepository
 
-interface ExpenseRepository : MongoRepository<Expense, ObjectId> {
+interface ExpenseRepository : MongoRepository<Expense, ObjectId>, ExpenseRepositoryCustom {
 
     fun findByOwnerId(ownerId: ObjectId): List<Expense>
 

--- a/src/main/kotlin/com/nv/expensetracker/database/repository/ExpenseRepositoryCustom.kt
+++ b/src/main/kotlin/com/nv/expensetracker/database/repository/ExpenseRepositoryCustom.kt
@@ -1,0 +1,10 @@
+package com.nv.expensetracker.database.repository
+
+import com.nv.expensetracker.database.model.Expense
+import org.bson.types.ObjectId
+import org.springframework.data.domain.Pageable
+import org.springframework.data.domain.Sort
+
+interface ExpenseRepositoryCustom {
+    fun search(ownerId: ObjectId, filter: ExpenseFilter, sort: Sort, pageable: Pageable? = null): List<Expense>
+}

--- a/src/main/kotlin/com/nv/expensetracker/database/repository/ExpenseRepositoryCustomImpl.kt
+++ b/src/main/kotlin/com/nv/expensetracker/database/repository/ExpenseRepositoryCustomImpl.kt
@@ -1,0 +1,49 @@
+package com.nv.expensetracker.database.repository
+
+import com.nv.expensetracker.database.model.Expense
+import org.bson.types.ObjectId
+import org.springframework.data.domain.Pageable
+import org.springframework.data.domain.Sort
+import org.springframework.data.mongodb.core.MongoTemplate
+import org.springframework.data.mongodb.core.query.Criteria
+import org.springframework.data.mongodb.core.query.Query
+import org.springframework.stereotype.Repository
+
+@Repository
+class ExpenseRepositoryCustomImpl(
+    private val mongoTemplate: MongoTemplate
+) : ExpenseRepositoryCustom {
+
+    override fun search(ownerId: ObjectId, filter: ExpenseFilter, sort: Sort, pageable: Pageable?): List<Expense> {
+        val criteriaList = mutableListOf<Criteria>()
+        criteriaList += Criteria.where("ownerId").`is`(ownerId)
+        filter.type?.let { criteriaList += Criteria.where("type").`is`(it) }
+        filter.date?.let { criteriaList += Criteria.where("date").`is`(it) }
+        if (filter.dateFrom != null || filter.dateTo != null) {
+            val dateCriteria = Criteria("date")
+            filter.dateFrom?.let { dateCriteria.gte(it) }
+            filter.dateTo?.let { dateCriteria.lte(it) }
+            criteriaList += dateCriteria
+        }
+        filter.amount?.let { criteriaList += Criteria.where("amount").`is`(it) }
+        if (filter.amountFrom != null || filter.amountTo != null) {
+            val amountCriteria = Criteria("amount")
+            filter.amountFrom?.let { amountCriteria.gte(it) }
+            filter.amountTo?.let { amountCriteria.lte(it) }
+            criteriaList += amountCriteria
+        }
+        filter.isRecurring?.let { criteriaList += Criteria.where("isRecurring").`is`(it) }
+        filter.search?.let { search ->
+            criteriaList += Criteria().orOperator(
+                Criteria.where("name").regex(search, "i"),
+                Criteria.where("description").regex(search, "i")
+            )
+        }
+
+        val criteria = Criteria().andOperator(*criteriaList.toTypedArray())
+        val query = Query(criteria).with(sort)
+        pageable?.let { query.with(it) }
+
+        return mongoTemplate.find(query, Expense::class.java)
+    }
+}


### PR DESCRIPTION
## Summary
- implement custom repository for dynamic expense queries
- expose filtering, sorting, and pagination in `GET /expenses`
- document new query parameters

## Testing
- `./gradlew test --no-daemon` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_685685abcb3c832d8a95cd8125cc4240