### PR TITLE
Implement saving goals

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,3 +21,27 @@ The `GET /expenses` endpoint now supports filtering, sorting and pagination.
 
 If `page` and `size` are provided the result is paginated; otherwise all
 matching expenses are returned.
+
+## Saving Goal Endpoints
+
+### `GET /saving-goal`
+Returns the current saving goal for the authenticated user. If no goal is set the response is `null`.
+
+### `POST /saving-goal`
+Creates a new saving goal. Only one goal per user is allowed.
+Request body:
+```json
+{
+  "name": "Vacation",
+  "targetAmount": 1000,
+  "targetDate": "2025-01-01T00:00:00Z"
+}
+```
+
+### `PUT /saving-goal/{id}`
+Updates an existing goal with the provided data.
+
+### `DELETE /saving-goal/{id}`
+Deletes the user's saving goal.
+
+The response object for creating or fetching the goal contains the amount already saved (based on expenses of type `SAVINGS`), progress ratio and the estimated monthly amount required to reach the goal by the target date.

--- a/src/main/kotlin/com/nv/expensetracker/controllers/SavingGoalController.kt
+++ b/src/main/kotlin/com/nv/expensetracker/controllers/SavingGoalController.kt
@@ -1,0 +1,125 @@
+package com.nv.expensetracker.controllers
+
+import com.nv.expensetracker.controllers.dto.SavingGoalRequest
+import com.nv.expensetracker.controllers.dto.SavingGoalResponse
+import com.nv.expensetracker.controllers.enums.ExpenseType
+import com.nv.expensetracker.database.model.SavingGoal
+import com.nv.expensetracker.database.repository.ExpenseFilter
+import com.nv.expensetracker.database.repository.ExpenseRepository
+import com.nv.expensetracker.database.repository.SavingGoalRepository
+import jakarta.validation.Valid
+import org.bson.types.ObjectId
+import org.springframework.http.HttpStatus
+import org.springframework.security.core.context.SecurityContextHolder
+import org.springframework.web.bind.annotation.DeleteMapping
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.PutMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+import org.springframework.web.server.ResponseStatusException
+import java.time.Duration
+import java.time.Instant
+import kotlin.math.ceil
+
+@RestController
+@RequestMapping("/saving-goal")
+class SavingGoalController(
+    private val repository: SavingGoalRepository,
+    private val expenseRepository: ExpenseRepository,
+) {
+
+    @GetMapping
+    fun getGoal(): SavingGoalResponse? {
+        val ownerId = ObjectId(SecurityContextHolder.getContext().authentication.principal as String)
+        val goal = repository.findByOwnerId(ownerId) ?: return null
+        return goal.toResponse(ownerId)
+    }
+
+    @PostMapping
+    fun createGoal(
+        @Valid @RequestBody body: SavingGoalRequest
+    ): SavingGoalResponse {
+        val ownerId = ObjectId(SecurityContextHolder.getContext().authentication.principal as String)
+        if (repository.findByOwnerId(ownerId) != null) {
+            throw ResponseStatusException(HttpStatus.CONFLICT, "Saving goal already exists")
+        }
+        val goal = repository.save(
+            SavingGoal(
+                id = body.id?.let { ObjectId(it) } ?: ObjectId.get(),
+                ownerId = ownerId,
+                name = body.name,
+                targetAmount = body.targetAmount,
+                targetDate = body.targetDate,
+            )
+        )
+        return goal.toResponse(ownerId)
+    }
+
+    @PutMapping(path = ["/{id}"])
+    fun updateGoal(
+        @PathVariable id: String,
+        @Valid @RequestBody body: SavingGoalRequest
+    ): SavingGoalResponse {
+        val ownerId = ObjectId(SecurityContextHolder.getContext().authentication.principal as String)
+        val goal = repository.findById(ObjectId(id)).orElseThrow {
+            ResponseStatusException(HttpStatus.NOT_FOUND, "Goal not found")
+        }
+        if (goal.ownerId != ownerId) {
+            throw ResponseStatusException(HttpStatus.NOT_FOUND, "Goal not found")
+        }
+        val updated = repository.save(
+            goal.copy(
+                name = body.name,
+                targetAmount = body.targetAmount,
+                targetDate = body.targetDate,
+            )
+        )
+        return updated.toResponse(ownerId)
+    }
+
+    @DeleteMapping(path = ["/{id}"])
+    fun deleteGoal(@PathVariable id: String) {
+        val ownerId = ObjectId(SecurityContextHolder.getContext().authentication.principal as String)
+        val goal = repository.findById(ObjectId(id)).orElseThrow {
+            ResponseStatusException(HttpStatus.NOT_FOUND, "Goal not found")
+        }
+        if (goal.ownerId != ownerId) {
+            throw ResponseStatusException(HttpStatus.NOT_FOUND, "Goal not found")
+        }
+        repository.delete(goal)
+    }
+
+    private fun SavingGoal.toResponse(ownerId: ObjectId): SavingGoalResponse {
+        val expenses = expenseRepository.search(
+            ownerId,
+            ExpenseFilter(type = ExpenseType.SAVINGS),
+            org.springframework.data.domain.Sort.unsorted(),
+            null
+        )
+        val saved = expenses.sumOf { it.amount }
+        val progress = if (targetAmount == 0) 0.0 else saved.toDouble() / targetAmount
+        val monthly = calculateMonthlyRequired(saved)
+        return SavingGoalResponse(
+            id = id.toHexString(),
+            name = name,
+            targetAmount = targetAmount,
+            targetDate = targetDate,
+            savedAmount = saved,
+            progress = progress,
+            monthlyRequired = monthly,
+        )
+    }
+
+    private fun SavingGoal.calculateMonthlyRequired(saved: Int): Int {
+        val remaining = targetAmount - saved
+        if (remaining <= 0) return 0
+        val now = Instant.now()
+        if (!targetDate.isAfter(now)) return remaining
+        val daysLeft = Duration.between(now, targetDate).toDays()
+        val monthsLeft = ceil(daysLeft / 30.0).toLong()
+        return if (monthsLeft <= 0) remaining else ceil(remaining.toDouble() / monthsLeft).toInt()
+    }
+}

--- a/src/main/kotlin/com/nv/expensetracker/controllers/dto/SavingGoalRequest.kt
+++ b/src/main/kotlin/com/nv/expensetracker/controllers/dto/SavingGoalRequest.kt
@@ -1,0 +1,14 @@
+package com.nv.expensetracker.controllers.dto
+
+import jakarta.validation.constraints.Min
+import jakarta.validation.constraints.NotBlank
+import java.time.Instant
+
+data class SavingGoalRequest(
+    val id: String?,
+    @field:NotBlank(message = "Goal name can't be empty.")
+    val name: String,
+    @field:Min(value = 1, message = "Target amount must be positive.")
+    val targetAmount: Int,
+    val targetDate: Instant,
+)

--- a/src/main/kotlin/com/nv/expensetracker/controllers/dto/SavingGoalResponse.kt
+++ b/src/main/kotlin/com/nv/expensetracker/controllers/dto/SavingGoalResponse.kt
@@ -1,0 +1,13 @@
+package com.nv.expensetracker.controllers.dto
+
+import java.time.Instant
+
+data class SavingGoalResponse(
+    val id: String,
+    val name: String,
+    val targetAmount: Int,
+    val targetDate: Instant,
+    val savedAmount: Int,
+    val progress: Double,
+    val monthlyRequired: Int,
+)

--- a/src/main/kotlin/com/nv/expensetracker/database/model/SavingGoal.kt
+++ b/src/main/kotlin/com/nv/expensetracker/database/model/SavingGoal.kt
@@ -1,0 +1,16 @@
+package com.nv.expensetracker.database.model
+
+import org.bson.types.ObjectId
+import org.springframework.data.annotation.Id
+import org.springframework.data.mongodb.core.mapping.Document
+import java.time.Instant
+
+@Document("saving_goals")
+data class SavingGoal(
+    @Id val id: ObjectId = ObjectId.get(),
+    val ownerId: ObjectId,
+    val name: String,
+    val targetAmount: Int,
+    val targetDate: Instant,
+    val createdAt: Instant = Instant.now(),
+)

--- a/src/main/kotlin/com/nv/expensetracker/database/repository/SavingGoalRepository.kt
+++ b/src/main/kotlin/com/nv/expensetracker/database/repository/SavingGoalRepository.kt
@@ -1,0 +1,9 @@
+package com.nv.expensetracker.database.repository
+
+import com.nv.expensetracker.database.model.SavingGoal
+import org.bson.types.ObjectId
+import org.springframework.data.mongodb.repository.MongoRepository
+
+interface SavingGoalRepository : MongoRepository<SavingGoal, ObjectId> {
+    fun findByOwnerId(ownerId: ObjectId): SavingGoal?
+}

--- a/src/test/kotlin/com/nv/expensetracker/ExpenseTrackerApplicationTests.kt
+++ b/src/test/kotlin/com/nv/expensetracker/ExpenseTrackerApplicationTests.kt
@@ -1,6 +1,7 @@
 package com.nv.expensetracker
 
 import com.nv.expensetracker.security.AuthService
+import com.nv.expensetracker.database.repository.SavingGoalRepository
 import org.junit.jupiter.api.Assertions.assertNotNull
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
@@ -9,12 +10,16 @@ import org.springframework.boot.test.context.SpringBootTest
 @SpringBootTest
 class ExpenseTrackerApplicationTests {
 
-	@Autowired
-	lateinit var authService: AuthService
+        @Autowired
+        lateinit var authService: AuthService
+
+        @Autowired
+        lateinit var savingGoalRepository: SavingGoalRepository
 
 	@Test
-	fun contextLoads() {
-		assertNotNull(authService)
-	}
+        fun contextLoads() {
+                assertNotNull(authService)
+                assertNotNull(savingGoalRepository)
+        }
 
 }


### PR DESCRIPTION
## Summary
- add `SavingGoal` model and repository
- support creating, updating, fetching and deleting a saving goal
- expose REST controller for new `/saving-goal` endpoints
- document saving goal endpoints in README
- basic test covers new repository bean

## Testing
- `./gradlew test --no-daemon` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_6856c267b0bc832dbea5f313c31e42d9