### PR TITLE
Add profile features and logout

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,3 +45,14 @@ Updates an existing goal with the provided data.
 Deletes the user's saving goal.
 
 The response object for creating or fetching the goal contains the amount already saved (based on expenses of type `SAVINGS`), progress ratio and the estimated monthly amount required to reach the goal by the target date.
+
+## Profile Endpoints
+
+### `GET /profile`
+Returns the authenticated user's profile information.
+
+### `DELETE /profile`
+Deletes the user account along with all associated data.
+
+### `POST /auth/logout`
+Invalidates the provided refresh token.

--- a/src/main/kotlin/com/nv/expensetracker/controllers/AuthController.kt
+++ b/src/main/kotlin/com/nv/expensetracker/controllers/AuthController.kt
@@ -49,4 +49,11 @@ class AuthController(
     ): TokenPair =
         authService.refresh(body.refreshToken)
 
+    @PostMapping(path = ["/logout"])
+    fun logout(
+        @RequestBody body: RefreshRequest
+    ) {
+        authService.logout(body.refreshToken)
+    }
+
 }

--- a/src/main/kotlin/com/nv/expensetracker/controllers/ProfileController.kt
+++ b/src/main/kotlin/com/nv/expensetracker/controllers/ProfileController.kt
@@ -1,0 +1,81 @@
+package com.nv.expensetracker.controllers
+
+import com.nv.expensetracker.controllers.dto.ProfileResponse
+import com.nv.expensetracker.database.model.Expense
+import com.nv.expensetracker.database.repository.ExpenseRepository
+import com.nv.expensetracker.database.repository.RefreshTokenRepository
+import com.nv.expensetracker.database.repository.SavingGoalRepository
+import com.nv.expensetracker.database.repository.UserRepository
+import com.nv.expensetracker.controllers.enums.ExpenseCategory
+import org.bson.types.ObjectId
+import org.springframework.http.HttpStatus
+import org.springframework.security.core.context.SecurityContextHolder
+import org.springframework.web.bind.annotation.DeleteMapping
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+import org.springframework.web.server.ResponseStatusException
+
+@RestController
+@RequestMapping("/profile")
+class ProfileController(
+    private val userRepository: UserRepository,
+    private val expenseRepository: ExpenseRepository,
+    private val savingGoalRepository: SavingGoalRepository,
+    private val refreshTokenRepository: RefreshTokenRepository,
+) {
+
+    @GetMapping
+    fun getProfile(): ProfileResponse {
+        val userId = ObjectId(SecurityContextHolder.getContext().authentication.principal as String)
+        val user = userRepository.findById(userId).orElseThrow {
+            ResponseStatusException(HttpStatus.NOT_FOUND, "User not found")
+        }
+        val expenses = expenseRepository.findByOwnerId(userId)
+        val userType = determineUserType(expenses)
+        val achievements = determineAchievements(userId, expenses)
+        return ProfileResponse(
+            email = user.email,
+            userType = userType,
+            achievements = achievements,
+        )
+    }
+
+    @DeleteMapping
+    fun deleteAccount() {
+        val userId = ObjectId(SecurityContextHolder.getContext().authentication.principal as String)
+        userRepository.deleteById(userId)
+        val expenses = expenseRepository.findByOwnerId(userId)
+        expenseRepository.deleteAll(expenses)
+        savingGoalRepository.findByOwnerId(userId)?.let { savingGoalRepository.delete(it) }
+        refreshTokenRepository.deleteAllByUserId(userId)
+    }
+
+    private fun determineUserType(expenses: List<Expense>): String {
+        if (expenses.isEmpty()) return "Newcomer"
+        val totals = expenses.groupBy { it.category }
+            .mapValues { entry -> entry.value.sumOf { it.amount } }
+        val topCategory = totals.maxByOrNull { it.value }?.key ?: return "Newcomer"
+        return when (topCategory) {
+            ExpenseCategory.TRAVEL -> "Traveler"
+            ExpenseCategory.FOOD_AND_DRINK -> "Foodie"
+            ExpenseCategory.ENTERTAINMENT -> "Entertainment Lover"
+            ExpenseCategory.ESSENTIALS -> "Practical Spender"
+            ExpenseCategory.HEALTH -> "Health Conscious"
+            ExpenseCategory.EDUCATION -> "Learner"
+            ExpenseCategory.HOME -> "Home Improver"
+            ExpenseCategory.PERSONAL -> "Self-Care Enthusiast"
+            ExpenseCategory.MISC -> "All-Rounder"
+        }
+    }
+
+    private fun determineAchievements(userId: ObjectId, expenses: List<Expense>): List<String> {
+        val achievements = mutableListOf<String>()
+        if (expenses.isNotEmpty()) achievements += "First Expense Added"
+        if (expenses.sumOf { it.amount } > 1000) achievements += "Spent over 1000"
+        if (expenses.any { it.isRecurring }) achievements += "Added Recurring Expense"
+        if (savingGoalRepository.findByOwnerId(userId) != null) achievements += "Saving Goal Set"
+        return achievements
+    }
+}
+

--- a/src/main/kotlin/com/nv/expensetracker/controllers/dto/ProfileResponse.kt
+++ b/src/main/kotlin/com/nv/expensetracker/controllers/dto/ProfileResponse.kt
@@ -1,0 +1,7 @@
+package com.nv.expensetracker.controllers.dto
+
+data class ProfileResponse(
+    val email: String,
+    val userType: String,
+    val achievements: List<String>,
+)

--- a/src/main/kotlin/com/nv/expensetracker/database/repository/RefreshTokenRepository.kt
+++ b/src/main/kotlin/com/nv/expensetracker/database/repository/RefreshTokenRepository.kt
@@ -10,4 +10,6 @@ interface RefreshTokenRepository: MongoRepository<RefreshToken, ObjectId> {
 
     fun deleteByUserIdAndHashedToken(userId: ObjectId, hashedToken: String)
 
+    fun deleteAllByUserId(userId: ObjectId)
+
 }

--- a/src/main/kotlin/com/nv/expensetracker/security/AuthService.kt
+++ b/src/main/kotlin/com/nv/expensetracker/security/AuthService.kt
@@ -94,6 +94,15 @@ class AuthService(
         )
     }
 
+    fun logout(refreshToken: String) {
+        if (!jwtService.validateRefreshToken(refreshToken)) {
+            throw ResponseStatusException(HttpStatusCode.valueOf(401), "Invalid refresh token.")
+        }
+        val userId = jwtService.getUserIdFromToken(refreshToken)
+        val hashed = hashToken(refreshToken)
+        refreshTokenRepository.deleteByUserIdAndHashedToken(ObjectId(userId), hashed)
+    }
+
     private fun hashToken(token: String): String {
         val digest = MessageDigest.getInstance("SHA-256")
         val hashBytes = digest.digest(token.encodeToByteArray())


### PR DESCRIPTION
## Summary
- implement new `/profile` controller with user info and account deletion
- provide DTO for profile response
- add logout logic and endpoint
- allow deleting all refresh tokens by user
- document new endpoints in README

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_6856c7ccd2f0832db6c88479efd84503