### PR TITLE
Fix login endpoint path

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,3 +56,20 @@ Deletes the user account along with all associated data.
 
 ### `POST /auth/logout`
 Invalidates the provided refresh token.
+
+## Authentication Endpoints
+
+`/register`, `/login`, `/refresh` and `/logout` are available without the `/auth` prefix.
+The legacy `/auth/*` paths continue to work.
+
+### `POST /register`
+Creates a new user account.
+
+### `POST /login`
+Retrieves an access and refresh token pair.
+
+### `POST /refresh`
+Returns a new token pair when provided a valid refresh token.
+
+### `POST /logout`
+Invalidates the provided refresh token.

--- a/src/main/kotlin/com/nv/expensetracker/controllers/AuthController.kt
+++ b/src/main/kotlin/com/nv/expensetracker/controllers/AuthController.kt
@@ -11,7 +11,7 @@ import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RestController
 
 @RestController
-@RequestMapping(path = ["/auth"])
+@RequestMapping(path = ["", "/auth"])
 class AuthController(
     private val authService: AuthService
 ) {

--- a/src/main/kotlin/com/nv/expensetracker/security/SecurityConfig.kt
+++ b/src/main/kotlin/com/nv/expensetracker/security/SecurityConfig.kt
@@ -24,6 +24,10 @@ class SecurityConfig(
                 auth
                     .requestMatchers(
                         "/auth/**",
+                        "/login",
+                        "/register",
+                        "/refresh",
+                        "/logout",
                         "/v3/api-docs/**",
                         "/swagger-ui/**",
                         "/swagger-ui.html",


### PR DESCRIPTION
## Summary
- allow auth endpoints without `/auth` prefix
- document login/register routes

## Testing
- `./gradlew test --no-daemon` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_685d4a55aa58832dbf0b97eba80e60fd