### PR TITLE
Improve register flow to return auth tokens

### DIFF
--- a/src/main/kotlin/com/nv/expensetracker/controllers/AuthController.kt
+++ b/src/main/kotlin/com/nv/expensetracker/controllers/AuthController.kt
@@ -33,9 +33,8 @@ class AuthController(
     @PostMapping(path = ["/register"])
     fun register(
         @Valid @RequestBody body: AuthRequest
-    ) {
+    ): TokenPair =
         authService.register(body.email, body.password)
-    }
 
     @PostMapping(path = ["/login"])
     fun login(


### PR DESCRIPTION
## Summary
- on sign up, create a session and return JWT tokens

## Testing
- `./gradlew test --no-daemon` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_6878f8dd2b40832d97ce2546a8914616